### PR TITLE
feat: add cyberpunk UI kit and cleanup inline styles

### DIFF
--- a/css/cyberpunk.css
+++ b/css/cyberpunk.css
@@ -1,0 +1,74 @@
+@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Tektur:wght@400;700&display=swap');
+
+:root {
+  --color-bg: #001a64;
+  --color-primary: #3ecdef;
+  --color-accent: #fd1d75;
+  --font-base: 'Montserrat', sans-serif;
+  --font-display: 'Tektur', sans-serif;
+}
+
+body {
+  background-color: var(--color-bg);
+  color: var(--color-primary);
+  font-family: var(--font-base);
+  margin: 0;
+}
+
+.btn {
+  background-color: var(--color-accent);
+  border: none;
+  color: #fff;
+  border-radius: 4px;
+  padding: 0.5rem 1rem;
+  transition: background 0.3s, transform 0.3s;
+}
+
+.btn:hover {
+  background-color: var(--color-primary);
+  transform: scale(1.05);
+}
+
+.card {
+  background-color: rgba(0, 26, 100, 0.6);
+  border: 1px solid var(--color-primary);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.form-control {
+  background-color: transparent;
+  border: 1px solid var(--color-primary);
+  border-radius: 4px;
+  color: #fff;
+}
+
+.nav {
+  background-color: rgba(0, 0, 0, 0.4);
+  padding: 0.5rem;
+}
+
+.is-hidden {
+  display: none;
+}
+
+.modal-dialog-lg {
+  width: 700px;
+  max-width: 700px;
+}
+
+.modal-dialog-md {
+  width: 500px;
+  max-width: 500px;
+}
+
+.modal-body-pad {
+  padding: 20px 70px;
+}
+
+.btn-code {
+  width: 90px;
+  padding-left: 0;
+  padding-right: 0;
+  text-align: center;
+}

--- a/main.htm
+++ b/main.htm
@@ -1,17 +1,18 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-	<meta charset="UTF-8">
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title class="lang">Starting</title>
-	<script>
-		window.OnCommand_INFO = [];
-		function OnCommand (strCmd, strParam){
-			window.OnCommand_INFO.push({strCmd, strParam})
-		}</script>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title class="lang">Starting</title>
+        <link rel="stylesheet" href="css/cyberpunk.css">
+        <script>
+                window.OnCommand_INFO = [];
+                function OnCommand (strCmd, strParam){
+                        window.OnCommand_INFO.push({strCmd, strParam})
+                }</script>
 </head>
-<body style="background-color: black">
-	loading...
+<body>
+        loading...
 <script src='js/icafe.js'></script>
 <script>
 	(async()=>{

--- a/themes/icafemenu/login.htm
+++ b/themes/icafemenu/login.htm
@@ -44,7 +44,7 @@
 	<!-- dd:login div -->
 
 	<!-- st:admin exit div -->
-	<div class="adminexitDiv h-100 formDiv" style="display: none;">
+        <div class="adminexitDiv h-100 formDiv is-hidden">
 		<section class="h-100 d-flex align-items-center justify-content-center">
 			<div class="admin-exit-form-div" >
 				<form method="post" id="adminexitForm" role="form" class="form-horizontal text-center" onsubmit="return delay_execute(admin_exit_form_submit);">
@@ -63,7 +63,7 @@
 	<!-- ed:admin exit div -->
 
 	<!-- st:home-version-enter-cafe-id div -->
-	<div class="homecafeidDiv h-100" style="display: none;">
+        <div class="homecafeidDiv h-100 is-hidden">
 		<section class="h-100 d-flex align-items-center justify-content-center">
 			<div class="text-center col-3 home-cafeid-form-div" >
 				<form method="post" id="homecafeidForm" role="form" class="form-horizontal text-center" onsubmit="return delay_execute(homecafeid_form_submit);">
@@ -84,7 +84,7 @@
 
 <!-- st:modal:register-member -->
 <div class="modal myModalRegisterMember" tabindex="-1" role="dialog" aria-hidden="true" data-backdrop="static" data-keyboard="false">
-	<div class="modal-dialog modal-dialog-centered" role="document" style="width:700px; max-width:700px;">
+        <div class="modal-dialog modal-dialog-centered modal-dialog-lg" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
 				<h5 class="modal-title lang">Member</h5>
@@ -93,7 +93,7 @@
 				</button>
 			</div>
 			<form id="form-register-member" class="form-horizontal" onsubmit="return delay_execute(member_register);">
-				<div class="modal-body" style="padding: 20px 70px;">
+                            <div class="modal-body modal-body-pad">
 
 					<div class="row">
 						<div class="col-6">
@@ -169,7 +169,7 @@
 										<input type="text" class="form-control modal-input bg-transparent" name="member_sms_code" >
 									</div>
 									<div class="col-5">
-										<button type="button" style="width:90px; padding-left: 0px; padding-right: 0;text-align:center;" class="btn btn-primary" onclick="javascript:SmsClassFun.sendCode()" id="sms_timer_code" title="Get verification code">GetCode</button>
+                                                                                <button type="button" class="btn btn-primary btn-code" onclick="javascript:SmsClassFun.sendCode()" id="sms_timer_code" title="Get verification code">GetCode</button>
 									</div>
 								</div>
 							</div>
@@ -243,7 +243,7 @@
 
 <!-- modal:topup-login -->
 <div class="modal myModalTopupLogin" tabindex="-1" role="dialog" aria-hidden="true" data-backdrop="static" data-keyboard="false">
-	<div class="modal-dialog modal-dialog-centered" role="document" style="width:500px; max-width:500px;">
+        <div class="modal-dialog modal-dialog-centered modal-dialog-md" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
 				<h5 class="modal-title lang">Guest topup login</h5>
@@ -252,7 +252,7 @@
 				</button>
 			</div>
 			<form class="form-horizontal" onsubmit="return delay_execute(theTopupLogin.create_topup_qrcode);">
-				<div class="modal-body" style="padding: 20px 70px;">
+                            <div class="modal-body modal-body-pad">
 					<div class="row">
 						<div class="col-12">
 							<div class="form-group">
@@ -298,7 +298,7 @@
 
 <!-- modal:member-login  -->
 <div class="modal myModalMemberLogin" tabindex="-1" role="dialog" aria-hidden="true" data-backdrop="static" data-keyboard="false">
-	<div class="modal-dialog modal-dialog-centered" role="document" style="width:500px; max-width:500px;">
+        <div class="modal-dialog modal-dialog-centered modal-dialog-md" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
 				<h5 class="modal-title lang">Social login</h5>
@@ -316,7 +316,7 @@
 
 <!-- modal:member-register  -->
 <div class="modal myModalQRMemberRegister" tabindex="-1" role="dialog" aria-hidden="true" data-backdrop="static" data-keyboard="false">
-	<div class="modal-dialog modal-dialog-centered" role="document" style="width:500px; max-width:500px;">
+        <div class="modal-dialog modal-dialog-centered modal-dialog-md" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
 				<h5 class="modal-title lang">Register</h5>
@@ -333,7 +333,7 @@
 
 <!-- st:modal:club rules agreement- -->
 <div class="modal clubRulesModal" tabindex="-1" role="dialog" aria-hidden="true" data-backdrop="static" data-keyboard="false">
-	<div class="modal-dialog modal-dialog-centered" role="document" style="width:500px; max-width:500px;">
+        <div class="modal-dialog modal-dialog-centered modal-dialog-md" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
 				<h5 class="modal-title lang">Club Rules</h5>
@@ -350,7 +350,7 @@
 <!-- ed:modal:club rules agreement- -->
 <!-- st:modal:personal data agreement- -->
 <div class="modal personalDataModal" tabindex="-1" role="dialog" aria-hidden="true" data-backdrop="static" data-keyboard="false">
-	<div class="modal-dialog modal-dialog-centered" role="document" style="width:500px; max-width:500px;">
+        <div class="modal-dialog modal-dialog-centered modal-dialog-md" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
 				<h5 class="modal-title lang">Privacy Policy</h5>
@@ -368,7 +368,7 @@
 
 <!-- st:modal:forgot-password -->
 <div class="modal myModalForgotPassword" tabindex="-1" role="dialog" aria-hidden="true" data-backdrop="static" data-keyboard="false">
-	<div class="modal-dialog modal-dialog-centered" role="document" style="width:500px; max-width:500px;">
+        <div class="modal-dialog modal-dialog-centered modal-dialog-md" role="document">
 		<div class="modal-content">
 			<div class="modal-header">
 				<h5 class="modal-title lang">Forgot password</h5>
@@ -377,7 +377,7 @@
 				</button>
 			</div>
 			<form id="form-forgot-password" class="form-horizontal" onsubmit="return delay_execute(theForgotPassword.submit_form);">
-				<div class="modal-body" style="padding: 20px 70px;">
+                            <div class="modal-body modal-body-pad">
 					<div class="row">
 						<div class="col-12">
 							<div class="form-group">

--- a/themes/icafemenu/main.htm
+++ b/themes/icafemenu/main.htm
@@ -6,12 +6,13 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 	<title>iCafeCloud Client</title>
-	<link rel="shortcut icon" href="images/favicon.ico" />
-	<script src="../../core/core.js"></script>
-	<script>
-		ICAFEMENU_CORE.loadCoreStyle(document);
-	</script>
-	<link rel="stylesheet" type="text/css" href="css/style.css">
+        <link rel="shortcut icon" href="images/favicon.ico" />
+        <script src="../../core/core.js"></script>
+        <script>
+                ICAFEMENU_CORE.loadCoreStyle(document);
+        </script>
+        <link rel="stylesheet" href="../../css/cyberpunk.css">
+        <link rel="stylesheet" type="text/css" href="css/style.css">
 	
 </head>
 <body ondragstart="return false" onselectstart = "return false" class="bs-c br-n ba-f text-gray" :style="vueGlobal.bodyStyle" @vue:mounted="mounted()" v-cloak>


### PR DESCRIPTION
## Summary
- add reusable cyberpunk theme CSS with neon palette
- link theme stylesheet and remove inline body styling
- convert login modals to class-based styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be9531d658832b9e26f138f147fd5d