### PR TITLE
Load cyberpunk theme styles inside theme templates

### DIFF
--- a/main.htm
+++ b/main.htm
@@ -4,7 +4,6 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title class="lang">Starting</title>
-        <link rel="stylesheet" href="css/cyberpunk.css">
         <script>
                 window.OnCommand_INFO = [];
                 function OnCommand (strCmd, strParam){

--- a/themes/reborn/main.htm
+++ b/themes/reborn/main.htm
@@ -1,3 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <link rel="stylesheet" href="../../css/cyberpunk.css">
+</head>
+<body>
 <script>
-	location.href = "app.htm"
+        location.href = "app.htm";
 </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove global cyberpunk stylesheet link from main loader page
- include cyberpunk stylesheet in reborn theme so styles persist after redirect

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bea705546c832bbce62e433c99f7be