### PR TITLE
feat: add cyberpunk redesign with theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,18 @@
 			- manifest.json		// 主题信息
 		- reborn
   		- ...
-		- icafemenu_theme_v2
-			- **main.htm**
+                - icafemenu_theme_v2
+                        - **main.htm**
+
+## Cyberpunk Theme
+
+The UI uses `css/cyberpunk.css` to provide a Cyberpunk Dojo look. Colors and fonts are configured via CSS variables:
+
+```
+--bg, --primary, --accent, --accent-2, --info, --blue, --neon-pink
+```
+
+### Theme toggle
+
+A button with id `theme-toggle` switches between dark and light modes. The choice is saved in `localStorage` and applied on load.
+

--- a/css/cyberpunk.css
+++ b/css/cyberpunk.css
@@ -1,74 +1,175 @@
 @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Tektur:wght@400;700&display=swap');
 
 :root {
-  --color-bg: #001a64;
-  --color-primary: #3ecdef;
-  --color-accent: #fd1d75;
-  --font-base: 'Montserrat', sans-serif;
-  --font-display: 'Tektur', sans-serif;
+  --bg: #001a64;
+  --primary: #3ecdef;
+  --accent: #fd1d75;
+  --accent-2: #ff6361;
+  --info: #a9e4ee;
+  --blue: #055ccc;
+  --neon-pink: #f601c0;
+
+  --font-heading: 'Tektur', sans-serif;
+  --font-body: 'Montserrat', sans-serif;
+
+  --radius: 6px;
+  --shadow: 0 0 10px rgba(0,0,0,0.5);
+  --transition: 0.2s;
+}
+
+html.light {
+  --bg: #ffffff;
+  --primary: #055ccc;
+  --accent: #fd1d75;
+  --accent-2: #ff6361;
+  --info: #001a64;
+  --blue: #055ccc;
+  --neon-pink: #f601c0;
 }
 
 body {
-  background-color: var(--color-bg);
-  color: var(--color-primary);
-  font-family: var(--font-base);
-  margin: 0;
+  background: var(--bg);
+  color: var(--primary);
+  font-family: var(--font-body);
+  margin:0;
+  line-height:1.5;
 }
+
+a { color: var(--primary); }
+a.no-decoration { text-decoration:none; }
+
+* { box-sizing:border-box; }
+
+.inline-block { display:inline-block !important; }
+.pre-wrap { white-space:pre-wrap; }
+.w-266 { width:266px; }
 
 .btn {
-  background-color: var(--color-accent);
-  border: none;
-  color: #fff;
-  border-radius: 4px;
-  padding: 0.5rem 1rem;
-  transition: background 0.3s, transform 0.3s;
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  border-radius: var(--radius);
+  padding:0.5rem 1rem;
+  border:1px solid transparent;
+  cursor:pointer;
+  transition: background var(--transition), color var(--transition), box-shadow var(--transition);
+  font-family: var(--font-body);
 }
 
-.btn:hover {
-  background-color: var(--color-primary);
-  transform: scale(1.05);
+.btn-primary { background: var(--primary); color:#000; }
+.btn-primary:hover { box-shadow:0 0 6px var(--primary); }
+
+.btn-ghost { background:transparent; border-color: var(--primary); color: var(--primary); }
+.btn-ghost:hover { background: rgba(255,255,255,0.1); }
+
+.btn-danger { background: var(--accent); color:#fff; }
+.btn-danger:hover { box-shadow:0 0 6px var(--accent); }
+
+input, select, textarea {
+  background: rgba(0,0,0,0.2);
+  border:1px solid var(--primary);
+  border-radius: var(--radius);
+  color: var(--primary);
+  padding:0.5rem;
+  font-family: var(--font-body);
 }
+
+input::placeholder, textarea::placeholder { color: var(--info); }
+
+input:focus-visible, select:focus-visible, textarea:focus-visible, .btn:focus-visible {
+  outline:2px solid var(--accent);
+  outline-offset:2px;
+}
+
+input[type=checkbox] {
+  accent-color: var(--accent);
+}
+
+.switch {
+  position:relative;
+  display:inline-block;
+  width:40px;
+  height:20px;
+}
+.switch input { opacity:0; width:0; height:0; }
+.slider {
+  position:absolute;
+  cursor:pointer;
+  top:0; left:0; right:0; bottom:0;
+  background-color: rgba(255,255,255,0.2);
+  transition: .4s;
+  border-radius: var(--radius);
+}
+.slider:before {
+  position:absolute;
+  content:""; height:14px; width:14px;
+  left:3px; bottom:3px; background-color: var(--primary);
+  transition:.4s; border-radius:50%;
+}
+input:checked + .slider { background-color: var(--accent); }
+input:checked + .slider:before { transform: translateX(20px); }
 
 .card {
-  background-color: rgba(0, 26, 100, 0.6);
-  border: 1px solid var(--color-primary);
-  border-radius: 8px;
-  padding: 1rem;
+  background: rgba(0,0,0,0.3);
+  border:1px solid var(--primary);
+  border-radius: var(--radius);
+  padding:1rem;
+  box-shadow: var(--shadow);
 }
 
-.form-control {
-  background-color: transparent;
-  border: 1px solid var(--color-primary);
-  border-radius: 4px;
-  color: #fff;
+.tabs { display:flex; border-bottom:1px solid var(--primary); }
+.tabs button {
+  border:none;
+  background:none;
+  padding:0.5rem 1rem;
+  cursor:pointer;
+  color: var(--info);
+}
+.tabs button.active {
+  color: var(--primary);
+  border-bottom:2px solid var(--accent);
 }
 
-.nav {
-  background-color: rgba(0, 0, 0, 0.4);
-  padding: 0.5rem;
+.modal {
+  background: rgba(0,0,0,0.6);
 }
-
-.is-hidden {
-  display: none;
+.modal-content {
+  background: var(--bg);
+  border-radius: var(--radius);
+  border:1px solid var(--primary);
+  box-shadow: var(--shadow);
 }
+.modal-body-pad { padding:20px 70px; }
+.modal-dialog-lg { width:700px; max-width:700px; }
+.modal-dialog-md { width:500px; max-width:500px; }
 
-.modal-dialog-lg {
-  width: 700px;
-  max-width: 700px;
-}
-
-.modal-dialog-md {
-  width: 500px;
-  max-width: 500px;
-}
-
-.modal-body-pad {
-  padding: 20px 70px;
+.toast {
+  background: var(--primary);
+  color:#000;
+  padding:0.5rem 1rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
 }
 
 .btn-code {
-  width: 90px;
-  padding-left: 0;
-  padding-right: 0;
-  text-align: center;
+  width:90px;
+  padding-left:0;
+  padding-right:0;
+  text-align:center;
+}
+
+.is-hidden { display:none; }
+
+.theme-toggle {
+  position:fixed;
+  top:1rem;
+  right:1rem;
+  z-index:1000;
+}
+
+@media (min-width:768px) {
+  .container { max-width:720px; margin:0 auto; }
+}
+@media (min-width:1200px) {
+  .container { max-width:1140px; }
 }

--- a/js/theme-toggle.js
+++ b/js/theme-toggle.js
@@ -1,0 +1,23 @@
+(function(){
+  const STORAGE_KEY = 'theme';
+  const root = document.documentElement;
+  function applyTheme(t){
+    if(t === 'light'){
+      root.classList.add('light');
+    } else {
+      root.classList.remove('light');
+    }
+  }
+  applyTheme(localStorage.getItem(STORAGE_KEY));
+  document.addEventListener('DOMContentLoaded', function(){
+    const btn = document.getElementById('theme-toggle');
+    if(!btn) return;
+    btn.addEventListener('click', function(){
+      const isLight = root.classList.contains('light');
+      const next = isLight ? 'dark' : 'light';
+      applyTheme(next);
+      localStorage.setItem(STORAGE_KEY, next);
+      btn.setAttribute('aria-label', next === 'light' ? 'Switch to dark theme' : 'Switch to light theme');
+    });
+  });
+})();

--- a/main.htm
+++ b/main.htm
@@ -4,6 +4,8 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title class="lang">Starting</title>
+        <link rel="stylesheet" href="css/cyberpunk.css">
+        <script src="js/theme-toggle.js" defer></script>
         <script>
                 window.OnCommand_INFO = [];
                 function OnCommand (strCmd, strParam){

--- a/themes/icafemenu/login.htm
+++ b/themes/icafemenu/login.htm
@@ -177,11 +177,11 @@
 					</div>
 					<div class="row" id="club-rule-agreement-row">
 						<div class="col-12">
-							<div class="form-check form-check-inline" style="display: inline-block !important;">
+                                                    <div class="form-check form-check-inline inline-block">
 								<label for="club-rule-agreement" class="form-check-label">
 									<input type="checkbox" class="form-check-input lang" id="club-rule-agreement" onclick="theMemberRegister.agreement_check()"/>
 									<label class="input-helper" for="club-rule-agreement"><span class="lang">
-										I have read and agree to the <a href="#" onclick="theMemberRegister.show_club_rules()" style="text-decoration: none;">club rules</a>
+                                                                            I have read and agree to the <a href="#" onclick="theMemberRegister.show_club_rules()" class="no-decoration">club rules</a>
 									</span></label>
 								</label>
 							</div>
@@ -189,11 +189,11 @@
 					</div>
 					<div class="row" id="personal-data-agreement-row">
 						<div class="col-12">
-							<div class="form-check form-check-inline" style="display: inline-block !important;">
+                                                    <div class="form-check form-check-inline inline-block">
 								<label for="personal-data-agreement" class="form-check-label">
 									<input type="checkbox" class="form-check-input lang" id="personal-data-agreement" onclick="theMemberRegister.agreement_check()"/>
 									<label class="input-helper" for="personal-data-agreement"><span class="lang">
-										I agree to the <a href="#" onclick="theMemberRegister.show_personal_data()" style="text-decoration: none;">privacy policy</a>
+                                                                            I agree to the <a href="#" onclick="theMemberRegister.show_personal_data()" class="no-decoration">privacy policy</a>
 									</span></label>
 								</label>
 							</div>
@@ -275,7 +275,7 @@
 						<div id="login_payment_qr" class="col-12 d-flex justify-content-center" data-clipboard-target="#login_payment_qr" @click="copyToClipboard('#login_payment_qr');">
 						</div>
 						<div id="login_payment_type" class="col-12 d-flex justify-content-center"  >
-							<img src="images/kaspi_qr.jpg" style="width: 266px;" class="d-none">
+                                                    <img src="images/kaspi_qr.jpg" class="d-none w-266">
 						</div>
 						<div id="login_payment_url" class="col-12 d-flex justify-content-center">
 							<div class="razorpay-qr-img">
@@ -342,7 +342,7 @@
 				</button>
 			</div>
 			<div class="modal-body">
-				<div id="club_rules_content" style="white-space: pre-wrap;"></div>
+                            <div id="club_rules_content" class="pre-wrap"></div>
 			</div>
 		</div>
 	</div>
@@ -359,7 +359,7 @@
 				</button>
 			</div>
 			<div class="modal-body">
-				<div id="personal_data_content" style="white-space: pre-wrap;"></div>
+                            <div id="personal_data_content" class="pre-wrap"></div>
 			</div>
 		</div>
 	</div>

--- a/themes/icafemenu/main.htm
+++ b/themes/icafemenu/main.htm
@@ -13,6 +13,7 @@
         </script>
         <link rel="stylesheet" href="../../css/cyberpunk.css">
         <link rel="stylesheet" type="text/css" href="css/style.css">
+        <script src="../../js/theme-toggle.js" defer></script>
 	
 </head>
 <body ondragstart="return false" onselectstart = "return false" class="bs-c br-n ba-f text-gray" :style="vueGlobal.bodyStyle" @vue:mounted="mounted()" v-cloak>
@@ -26,6 +27,8 @@
 <div id="page-event-modal"></div>
 <div id="page-system-settings-modal"></div>
 <div id="page-copy-game-license-modal"></div>
+
+<button id="theme-toggle" class="btn btn-ghost theme-toggle" aria-label="Toggle theme">🌓</button>
 
 <script>
 	function loadHtml(url, id)


### PR DESCRIPTION
## Summary
- introduce cyberpunk Dojo design system and dark/light variables
- add persistent theme toggle and cleaned inline styles in login and main pages
- document usage of new theme and variables

## Testing
- `npm test` *(fails: package.json missing)*

## Checklist
- [x] login
- [x] booking PC
- [x] balance top-up

------
https://chatgpt.com/codex/tasks/task_e_68beaacc8c6c832b9b508ee2a3296ce8